### PR TITLE
Show all the social links provided in a team file

### DIFF
--- a/_includes/team_profile.html
+++ b/_includes/team_profile.html
@@ -17,7 +17,10 @@
         <h3 class="mt-0 pb-1 text-2xl md:text-3xl text-green font-normal leading-tight tracking-wide border-b">{{ include.person.name }}</h3>
       {% endif %}
       <h3 class="text-xl md:text-2xl font-light leading-tight tracking-wide mt-1 mb-1">{{ include.person.role }}</h3>
-      <a class="inline-block w-12 text-grey-darker" href="{{ include.person.github }}">{% include svg/github.svg %}</a>
+      {% for link in include.person.social_links %}
+        {% assign svg = link[0] | prepend: 'svg/' | append: ".svg" %}
+        <a class="inline-block mr-1 w-12 text-grey-darker" href="{{ link[1] }}">{% include {{ svg }} %}</a>
+      {% endfor %}
     </div>
     <div class="mt-3 clear-left xl:overflow-y-auto mb-16">
       {{ include.person.content | markdownify }}

--- a/_team/MiguelRuizDev.md
+++ b/_team/MiguelRuizDev.md
@@ -1,6 +1,7 @@
 --- 
 name: Miguel Ruiz
 role: Activiti Intern Developer
-github: https://github.com/MiguelRuizDev
+social_links:
+  github: https://github.com/MiguelRuizDev
 ---
 

--- a/_team/bassam-al-sarori.md
+++ b/_team/bassam-al-sarori.md
@@ -1,7 +1,8 @@
 --- 
 name: Bassam Al-Sarori
 role: Activiti Core Developer
-github: https://github.com/balsarori
+social_links:
+  github: https://github.com/balsarori
 ---
 
 Bassam has over 10 years of experience developing and delivering high performance systems. He boosts the performance of Activiti’s stateless REST-based APIs and helps integrate them into ever modern rich web clients.

--- a/_team/cijujoseph.md
+++ b/_team/cijujoseph.md
@@ -1,7 +1,8 @@
 --- 
 name: Ciju Joseph
 role: Activiti Core Developer
-linkedin: https://www.linkedin.com/in/ciju-joseph-09648b13/
-github: https://github.com/cijujoseph
+social_links:
+  linkedin: https://www.linkedin.com/in/ciju-joseph-09648b13/
+  github: https://github.com/cijujoseph
 ---
 Ciju is an experienced consultant with 14+ years of experience in the design and delivery of complex enterprise integration and BPM solutions. Experience and areas of interest includes: enterprise integration patterns, business process management & automation, modern cloud native frameworks & solutions etc. More about Ciju at https://www.linkedin.com/in/ciju-joseph-09648b13/

--- a/_team/constantin-ciobotaru.md
+++ b/_team/constantin-ciobotaru.md
@@ -1,6 +1,7 @@
 --- 
 name: Constantin Ciobotaru
 role: Activiti Developer
-github: https://github.com/constantin-ciobotaru
+social_links:
+  github: https://github.com/constantin-ciobotaru
 ---
 Software engineer with 15+ years of experience in developing enterprise applications. Worked before for Embarcadero, Intel, S&P, now involved in Alfresco Process Services and Activiti open source community.

--- a/_team/daisuke-yoshimoto.md
+++ b/_team/daisuke-yoshimoto.md
@@ -1,7 +1,8 @@
 --- 
 name: Daisuke Yoshimoto
 role: Activiti Core Developer
-github: https://github.com/daisuke-yoshimoto
+social_links:
+  github: https://github.com/daisuke-yoshimoto
 ---
 
 Daisuke is a software engineer at Japanese software company NTT DATA INTRAMART. He is one of the lead developers for IM-BPM, which uses Activiti Engine as a core BPM engine and adopts Activiti Designer as process modeling tool.

--- a/_team/elias-de-medeiros.md
+++ b/_team/elias-de-medeiros.md
@@ -1,7 +1,8 @@
 --- 
 name: Elias De Medeiros
 role: Activiti Core Developer
-github: https://github.com/erdemedeiros
+social_links:
+  github: https://github.com/erdemedeiros
 ---
 
 Elias is a clean coding and unit testing enthusiast. He brings 7 years of experience in Java and Process Engine related technologies. Elias previously worked at "UShareSoft a Fujitsu Company" and Bonitasoft, focused on the BPMN2 Process Engine and Cloud Tools.

--- a/_team/ffazzini.md
+++ b/_team/ffazzini.md
@@ -1,7 +1,8 @@
 --- 
 name: Francesco Fazzini
 role: Activiti Developer
-github: https://github.com/ffazzini
+social_links:
+  github: https://github.com/ffazzini
 ---
 IT professional with 10+ years expertise of Java development. Enthusiastic follower of Agile software development methodologies and problem solving, passionate about cloud technologies and big data.
 

--- a/_team/giuseppe-malanga.md
+++ b/_team/giuseppe-malanga.md
@@ -1,7 +1,8 @@
 --- 
 name: Giuseppe Malanga
 role: Activiti Developer
-github: https://github.com/gmalanga
+social_links:
+  github: https://github.com/gmalanga
 ---
 
 Giuseppe is solution architect at Zaizi with 7 years of experience in data management, data integration and business processes. He has been involved in several Alfresco and Activiti projects, for private and public sector, hosted on-premise or in the cloud. In recent months he designed and implemented case management solutions for public sector, which has required the integration between Activiti and microservices.

--- a/_team/greg-harley.md
+++ b/_team/greg-harley.md
@@ -1,7 +1,8 @@
 --- 
 name: Greg Harley
 role: Activiti Developer
-github: https://github.com/gdharley
+social_links:
+  github: https://github.com/gdharley
 ---
 
 Thirty plus years experience with a background in real-time supervisory control, content management and business process management. An expert in enterprise scale system architecture, and integration. Industry experience includes: banking, pharmacy, transportation, utility management, healthcare management, insurance, education, knowledge management, telecommunications, manufacturing and retail.

--- a/_team/igor-dianov.md
+++ b/_team/igor-dianov.md
@@ -1,7 +1,8 @@
 --- 
 name: Igor Dianov
 role: Activiti Core Developer
-github: https://github.com/igdianov
+social_links:
+  github: https://github.com/igdianov
 ---
 
 Igor Dianov brings 25+ years of experience in architecting, developing and managing software for scalable and persistent enterprise applications. In early 2015, Igor Dianov together with D.Sc.Mykhailo Dianov set out to develop a new concept of advanced & scalable enterprise application architecture blueprints by separating communication and application concerns and connecting client and server side services in a clean, controlled & secured manner (www.introproventures.com). Before co-founding IntroPro Ventures, Igor worked on enterprise software development in financial, telecommunication, content management, process management and content distribution applications for companies such as Sberbank, Telegroup, and PressReader (formely NewspaperDirect). He brings his experience building large-scale enterprise applications and vision for scalable software architecture and integrations leveraging mature open source software. Over the last 15 years of professional activity Igor Dianov was operating in the Greater Vancouver area, British Columbia, Canada. Igor Dianov graduated as MS in Electrical Engineering from National Technical University of Ukraine with specialization in Computer Systems for Experimental Research and Integrated Testing. In his leisure time, Igor is dedicated to sailing and racing windsurfers in Vancouver, BC and Oregon, US.

--- a/_team/lucianoprea.md
+++ b/_team/lucianoprea.md
@@ -1,6 +1,7 @@
 --- 
 name: Lucian Oprea
 role: Activiti Developer
-github: https://github.com/lucianoprea
+social_links:
+  github: https://github.com/lucianoprea
 ---
 Software engineer with 5+ years of experience in developing enterprise applications. Enthusiast about clean code, TDD, cloud technologies, unix and being involved in open source community.

--- a/_team/mauricio-salaboy-salatino.md
+++ b/_team/mauricio-salaboy-salatino.md
@@ -1,9 +1,10 @@
 --- 
 name: Mauricio "Salaboy" Salatino
 role: Activiti Tech Lead
-github: https://github.com/Salaboy
-linkedin: https://uk.linkedin.com/in/salaboy
-twitter: https://twitter.com/salaboy
+social_links:
+  github: https://github.com/Salaboy
+  linkedin: https://uk.linkedin.com/in/salaboy
+  twitter: https://twitter.com/salaboy
 ---
 
 Mauricio is a long term BPM, Rules Engine and Open Source enthusiast. Previously working for Red Hat, on their BPMS and BRMS, Mauricio published 4 books about BPM and Rule Engines. You can find more about Mauricio's work in his blog [salaboy.com](https://salaboy.com/) about Open Source, Business Automation, Artificial Intelligence and new technologies.

--- a/_team/mauriziovitale.md
+++ b/_team/mauriziovitale.md
@@ -1,6 +1,7 @@
 --- 
 name: Maurizio Vitale
 role: Activiti Developer
-github: https://github.com/mauriziovitale
+social_links:
+  github: https://github.com/mauriziovitale
 ---
 Maurizio is an experienced and self-motivated Software Engineer with a desire to create high-performance and scalable web applications. After having gained more than 10 years of experience in developing Enterprise Applications for banking and insurance services, he joined Alfresco in 2015 and has started to explore Open Source world, developing skills in Angular, Docker and Kubernetes.

--- a/_team/mteodori.md
+++ b/_team/mteodori.md
@@ -1,5 +1,6 @@
 --- 
 name: Marcello Teodori
 role: Activiti Developer
-github: https://github.com/mteodori
+social_links:
+  github: https://github.com/mteodori
 ---

--- a/_team/pancudaniel7.md
+++ b/_team/pancudaniel7.md
@@ -1,6 +1,7 @@
 --- 
 name: Pancu Daniel
 role: Activiti Developer
-github: https://github.com/pancudaniel7
+social_links:
+  github: https://github.com/pancudaniel7
 ---
 A full stack developer experience in a variety of exciting projects and technologies I am open to learn and apply new tehnical solutions for different problems. A rational approach to problem solving combined with a passion for innovative. A strong communicator with the ability to convey ideas clearly.

--- a/_team/ryan-dawson.md
+++ b/_team/ryan-dawson.md
@@ -1,7 +1,8 @@
 --- 
 name: Ryan Dawson
 role: Activiti Core Developer
-github: https://github.com/ryandawsonuk
+social_links:
+  github: https://github.com/ryandawsonuk
 ---
 
 Ryan brings to Activiti a broad background as a developer and consultant in Banking, Finance and Risk Management. Ryan uses that experience to help Activiti grow as a product which is both cutting edge and also easy to adopt and which satisfies the key needs of modern enterprises.


### PR DESCRIPTION
Up till now we've been showing a github link and only a github link - regardless of if a link was in the team file.

This refactors the team files slightly so that we can just loop over the social links and print them if they're provided.