### PR TITLE
Make the hidden partner opt in label visible in the sign up now form

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1063,7 +1063,8 @@ img {
   bottom: -100% !important;
 }
 
-label[for="emailOptIn"] {
+label[for="emailOptIn"],
+label[for="Partner_Opt_In__c"] {
   display: block;
   width: 100% !important;
 }


### PR DESCRIPTION
If you select Poland or Germany from the sign up now form, the label for the partner opt in is hidden. It should be visible in the same way the label for the email opt in is.