### PR TITLE
Issue #49352: Clip radio input to prevent click

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1018,6 +1018,7 @@ img {
 
 .mktoForm input[type=radio] {
   position: absolute !important;
+  clip: rect(1px, 1px, 1px, 1px);
 }
 
 .mktoForm input[type=radio] + label {

--- a/src/css/components/marketo-forms.css
+++ b/src/css/components/marketo-forms.css
@@ -45,6 +45,7 @@
 
 .mktoForm input[type=radio] {
   @apply .absolute !important;
+  clip: rect(1px, 1px, 1px, 1px);
 }
 
 .mktoForm input[type=radio] + label {


### PR DESCRIPTION
The original radio input element is transparent but fully interactive, leading to strange behaviour when clicking/tapping. With this change, we clip the radio input too so that it's not interactive.