### PR TITLE
Issue #49692: Marketo form for Enterprise link.

### DIFF
--- a/_data/main_menu_links.yml
+++ b/_data/main_menu_links.yml
@@ -12,3 +12,4 @@
   url: team.html
 - title: Enterprise
   url: https://www.alfresco.com/platform/process-services-bpm
+  data-most-recent-lead-source-detail: 2018_GLO_GLO_DG_Website_NP_Activiti7_Enterprise

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,11 +25,15 @@
         {% else %}
           {% assign item_url = item.url %}
         {% endif %}
-        <li><a class="block text-grey-darker font-normal <lg:border-t <lg:border-green <lg:pl-8 <lg:bg-grey-lighter <lg:hover:bg-grey-light text-xl lg:text-base py-3 lg:mx-4" href="{{ item_url }}">{{ item.title }}</a></li>
+        {% if item.data-most-recent-lead-source-detail %}
+          <li><a class="menu-link" href="{{ item_url }}" data-most-recent-lead-source-detail="{{ item.data-most-recent-lead-source-detail }}" data-modal="#before-you-start" data-redirect="{{ item_url }}">{{ item.title }}</a></li>
+        {% else %}
+          <li><a class="menu-link" href="{{ item_url }}">{{ item.title }}</a></li>
+        {% endif %}
       {% endfor %}
       {% unless page.path == 'before-you-start.html' %}
         <li class='lg:ml-auto'>
-          <a class='btn lg:py-1 <lg:py-3 <lg:block <lg:rounded-none <lg:bg-green <lg:hover:transform-none <lg:font-bold <lg:text-xl <lg:text-center' href="{% link before-you-start.html %}" data-modal="#before-you-start">Try Now</a>
+          <a class='btn lg:py-1 <lg:py-3 <lg:block <lg:rounded-none <lg:bg-green <lg:hover:transform-none <lg:font-bold <lg:text-xl <lg:text-center' href="{% link get-started.md %}" data-modal="#before-you-start">Try Now</a>
         </li>
       {% endunless %}
     </ul>

--- a/_includes/marketo-modal.html
+++ b/_includes/marketo-modal.html
@@ -3,7 +3,7 @@
 
   <div class="flex flex-wrap justify-center">
     <div class="card card__bleed card-except-below-large m-0 lg:mr-6 lg:w-2/5">
-      <noscript>You need Javascript enabled to do this.<br /><a href="{% link get-started.md %}">Continue on to get started.</a></noscript>
+      <noscript>You need Javascript enabled to do this.<br /><a href="{% link get-started.md %}" class="js-marketo-continue">Continue on to get started.</a></noscript>
       <div class="marketo-form__loader">
         <script type="text/javascript" src="//app-ab05.marketo.com/js/forms2/js/forms2.min.js"></script>
         <form data-privacy-message="Need more info? View Alfresco <a href='https://www.alfresco.com/privacy-statement' target='_blank'>Privacy</a> statement." id="mktoForm_3128" data-most-recent-lead-source-detail="2018_GLO_GLO_DG_Website_NP_Activiti7" data-google-event="ActivitiGettingStartedForm" data-redirect="{% link get-started.md %}" data-button-text="Download Now" data-protection-form="mktoForm_3128" data-protection-mode="soft" data-no-thanks="No Thanks. Continue" data-intro="Join over 6,000 Actitivi Users in the Community. Get tips, tricks, success cases, connect to other developers, quick start guides, help and much more in the Activiti Digest." data-opt-in-label="At Alfresco we realize the value of making connections, would you like to subscribe to emails from us?"></form>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1197,6 +1197,36 @@ label[for="Partner_Opt_In__c"] {
   }
 }
 
+.menu-link {
+  display: block;
+  color: #727174;
+  font-weight: 400;
+  font-size: 1.25rem;
+  padding-top: .9375rem;
+  padding-bottom: .9375rem;
+}
+
+@media (max-width: 768px) {
+  .menu-link {
+    border-top-width: 1px;
+    border-color: #22be73;
+    padding-left: 2.5rem;
+    background-color: #f9f9f9;
+  }
+
+  .menu-link:hover {
+    background-color: #eef0f0;
+  }
+}
+
+@media (min-width: 768px) {
+  .menu-link {
+    font-size: 1rem;
+    margin-left: 1.25rem;
+    margin-right: 1.25rem;
+  }
+}
+
 .hamburger {
   position: absolute;
   color: #727174;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,11 @@ const Q = require('q');
 const concat = require('gulp-concat');
 
 const cssFiles = "src/css/**/*.css";
+const jsFiles = [
+  'node_modules/jquery.cookie/jquery.cookie.js',
+  'node_modules/jquery-modal/jquery.modal.min.js',
+  'src/js/*.js',
+];
 const siteRoot = "_site";
 const tailwindConfig = "tailwind.js"; /* Tailwind config */
 
@@ -64,12 +69,7 @@ gulp.task("jekyll:watch", function() {
  * Compile JS
  */
 gulp.task('js', function () {
-  var files = [
-    'node_modules/jquery.cookie/jquery.cookie.js',
-    'node_modules/jquery-modal/jquery.modal.min.js',
-    'src/js/*.js',
-  ];
-  return gulp.src(files)
+  return gulp.src(jsFiles)
     .pipe(concat('all.js'))
     .pipe(gulp.dest('assets/js/'));
 });
@@ -138,6 +138,7 @@ gulp.task("serve", ["css", "js"], () => {
   });
 
   gulp.watch([cssFiles, tailwindConfig], { interval: 500 }, ['css']);
+  gulp.watch([jsFiles], { interval: 500 }, ['js']);
 });
 
 gulp.task("default", ['build']);

--- a/src/css/components/menu-link.css
+++ b/src/css/components/menu-link.css
@@ -1,0 +1,27 @@
+.menu-link {
+  @apply .block;
+  @apply .text-grey-darker;
+  @apply .font-normal;
+  @apply .text-xl;
+  @apply .py-3;
+}
+
+@media (max-width: config(screens.lg)) {
+  .menu-link {
+    @apply .border-t;
+    @apply .border-green;
+    @apply .pl-8;
+    @apply .bg-grey-lighter;
+  }
+
+  .menu-link:hover {
+    @apply .bg-grey-light;
+  }
+}
+
+@screen lg {
+  .menu-link {
+    @apply .text-base;
+    @apply .mx-4
+  }
+}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -45,6 +45,7 @@
 @import "components/headings";
 @import "components/marketo-forms";
 @import "components/main-menu";
+@import "components/menu-link";
 @import "components/hamburger";
 @import "components/modal";
 @import "components/hr-text-row";

--- a/src/js/get-started-modal.js
+++ b/src/js/get-started-modal.js
@@ -18,7 +18,7 @@
         $mktoForm = $('form[id*="mktoForm_"]', $modal);
         if ($mktoForm.length) {
           protectedForm = $mktoForm.data('protectionForm');
-          redirect = $mktoForm.data('redirect');
+          redirect = $this_link.data('redirect') || $mktoForm.data('redirect');
           if (protectedForm && redirect) {
             if ($.cookie('protected_form_completed' + protectedForm) === 'true') {
               $this_link.attr('href', redirect);
@@ -40,6 +40,19 @@
 
         if (modal_status) {
           var showModal = function(e) {
+            var latestLeadSourceVal = $(this).data('mostRecentLeadSourceDetail');
+            if (latestLeadSourceVal && latestLeadSourceVal.length > 0) {
+              $mktoForm.data('mostRecentLeadSourceDetail', latestLeadSourceVal);
+              var $latestLeadSourceElem = $(':input[name="mostRecentLeadSourceDetail"]', $mktoForm);
+              if ($latestLeadSourceElem.length > 0) {
+                $latestLeadSourceElem.val(latestLeadSourceVal);
+              }
+            }
+
+            var redirect = $(this).attr('href');
+            $mktoForm.data('redirect', redirect);
+            $('.js-marketo-continue, .mktoForm-no-thanks', $mktoForm).attr('href', redirect);
+
             $mktoForm.removeAttr('style').find('[style]').removeAttr('style');
 
             $modal.modal({


### PR DESCRIPTION
Notes:

* Various attributes are now passed to the marketo form from the 
  triggering link, so that different links can pass different things 
  (e.g. destination redirect & most recent lead source).
* New ‘menu-link’ CSS component to avoid repeated long set of classes in
  header.html
* ‘mostRecentLeadSource’ custom variable is pushed to the GA data layer.
* Non-JS fallback & middle-click protection has been lost, I trust that's not worth spending further time on.
* Gulp browsersync task includes watching for JS file changes now.
* There is a change in the compiled style.css that was not made first in
  the source CSS, made in ffa4f9. I have avoided committing any change 
  to that so it doesn’t get lost, but it will do someday, no doubt.