### PR TITLE
Issue #51582: Replace GTM script

### DIFF
--- a/_includes/google-tag-manager.html
+++ b/_includes/google-tag-manager.html
@@ -1,4 +1,15 @@
-<!-- Google Tag Manager -->
-<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-W4HV22" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<script type="text/javascript">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0];var j=d.createElement(s);var dl=l!='dataLayer'?'&l='+l:'';j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;j.type='text/javascript';j.async=true;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-W4HV22');</script>
-<!-- End Google Tag Manager -->
+<!-- START: Google Tag Manager -->
+<script>
+// Separate DEV and LIVE output for Google Tag Manager using Client-side switch.
+var GTMcode = "GTM-W4HV22";
+var myHostname = window.location.hostname;
+var isDevHostname = /(^|.+\.)((dev|preprod)\.alfresco\.com|localhost|local|([0-9]{1,3}\.){3}[0-9]{1,3})$/i;
+if( isDevHostname.exec(myHostname) ) {
+GTMcode = 'GTM-MZHX96P';   }; 
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore…
+})(window,document,'script','dataLayer', GTMcode );
+</script>
+<!-- END: Google Tag Manager -->


### PR DESCRIPTION
For https://support.computerminds.co.uk/issues/51582 . Note that the supplied script didn't include a `noscript` version, I trust that's acceptable? I'm not sure there's a good way we can switch the GTM ID according to the hostname when javascript isn't available.