### PR TITLE
Update cookie protection time to 14 days

### DIFF
--- a/src/js/marketo.js
+++ b/src/js/marketo.js
@@ -104,7 +104,7 @@ marketo.utils = {};
       // that the form has been filled in.
       if ($form.data('protectionForm')) {
         $.cookie('protected_form_completed' + $form.data('protectionForm'), 'true', {
-          expires: 30,
+          expires: 14,
           path: '/'
         });
       }


### PR DESCRIPTION
Hello, we want to reduce the expiration time from the cookie that protects the marketo form to 14 days. 

This request comes from Ian Norton.

@mteodori 

